### PR TITLE
Java and deps refresh and path style access

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11.0.10
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: '11.0.10'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -18,19 +18,15 @@ is not configuration for Apache Solr, the appender will not attempt to publish t
 
 ## Prerequisites
 
-The [packages in MVN Repo](https://mvnrepository.com/search?q=therealvan) should work
-for all Java versions 8+; you can just either download the JARs or add the appropriate dependency
-stanzas into your build configuration.
+The [packages in MVN Repo](https://mvnrepository.com/search?q=therealvan) should work as long as you're on the 
+correct Java version (see below).
 
-To build locally:
 
 Release / tag|JSDK version
 -----------|------------
 2.x and earlier|[Java SDK (JDK) 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
 3.x|[Java SDK (JDK) 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
 
-[Java SDK (JDK) 8](https://docs.oracle.com/javase/8/) is required **ONLY for cases when you want to build the projects
-locally**. 
 
 Note that using [Java SDK (JDK) 14](https://docs.oracle.com/en/java/javase/14/) to build the projects locally will
 have errors. You can try basing your work on [PR 59](https://github.com/bluedenim/log4j-s3-search/pull/59) if you

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <powermock.version>1.6.6</powermock.version>
+        <powermock.version>2.0.9</powermock.version>
     </properties>
 
     <dependencies>
@@ -128,9 +128,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>2.8.5-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>appender-core</name>
     <description>Core functionality to send content to various channels</description>
 
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>2.8.4</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -115,7 +115,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
-            <artifactId>transport</artifactId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
         </dependency>
 
         <dependency>

--- a/appender-core/src/main/java/com/van/logging/aws/AwsClientHelpers.java
+++ b/appender-core/src/main/java/com/van/logging/aws/AwsClientHelpers.java
@@ -38,7 +38,7 @@ public class AwsClientHelpers {
         return credProvider;
     }
 
-    static AwsClientBuilder getS3ClientBuilder() {
+    static AmazonS3ClientBuilder getS3ClientBuilder() {
         return AmazonS3ClientBuilder.standard();
     }
 
@@ -57,18 +57,22 @@ public class AwsClientHelpers {
      * @param region optional region to use.
      * @param serviceEndpoint optional service endpoint to use when initializing the S3 Client.
      * @param signingRegion optional signing region to use when initializing the S3 Client.
+     * @param pathStyleAccess optional boolean indicating if path style URL should be used
      *
      * @return the client class to use for S3 access.
      */
     public static AmazonS3 buildClient(
         String accessKey, String secretKey, String sessionToken,
         Region region,
-        String serviceEndpoint, String signingRegion
+        String serviceEndpoint, String signingRegion, boolean pathStyleAccess
     ) {
         AWSCredentialsProvider credentialsProvider =
             getCredentialsProvider(accessKey, secretKey, sessionToken);
-        AwsClientBuilder builder = getS3ClientBuilder();
+        AmazonS3ClientBuilder builder = getS3ClientBuilder();
         builder = builder.withCredentials(credentialsProvider);
+        if (pathStyleAccess) {
+            builder = builder.withPathStyleAccessEnabled(true);
+        }
         if (region != null) {
             builder = builder.withRegion(region.getName());
         }

--- a/appender-core/src/main/java/com/van/logging/aws/AwsClientHelpers.java
+++ b/appender-core/src/main/java/com/van/logging/aws/AwsClientHelpers.java
@@ -68,11 +68,9 @@ public class AwsClientHelpers {
     ) {
         AWSCredentialsProvider credentialsProvider =
             getCredentialsProvider(accessKey, secretKey, sessionToken);
-        AmazonS3ClientBuilder builder = getS3ClientBuilder();
-        builder = builder.withCredentials(credentialsProvider);
-        if (pathStyleAccess) {
-            builder = builder.withPathStyleAccessEnabled(true);
-        }
+        AmazonS3ClientBuilder builder = getS3ClientBuilder()
+            .withCredentials(credentialsProvider)
+            .withPathStyleAccessEnabled(pathStyleAccess);
         if (region != null) {
             builder = builder.withRegion(region.getName());
         }

--- a/appender-core/src/main/java/com/van/logging/aws/S3Configuration.java
+++ b/appender-core/src/main/java/com/van/logging/aws/S3Configuration.java
@@ -56,6 +56,7 @@ public class S3Configuration {
 
     private String serviceEndpoint = null;
     private String signingRegion = null;
+    private boolean pathStyleAccess = false;
 
     private boolean compressionEnabled = false;
     private S3SSEConfiguration sseConfiguration = null;
@@ -93,6 +94,9 @@ public class S3Configuration {
         return cannedAcl;
     }
 
+    public boolean isPathStyleAccess() {
+        return pathStyleAccess;
+    }
     /**
      * Sets the canned ACL for S3 to use when storing objects.
      *
@@ -140,6 +144,9 @@ public class S3Configuration {
     }
     public void setSigningRegion(String signingRegion) {
         this.signingRegion = signingRegion;
+    }
+    public void setPathStyleAccess(boolean pathStyleAccess) {
+        this.pathStyleAccess = pathStyleAccess;
     }
 
     public boolean isCompressionEnabled() {

--- a/appender-core/src/main/java/com/van/logging/aws/S3PublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/aws/S3PublishHelper.java
@@ -51,7 +51,8 @@ public class S3PublishHelper extends AbstractFilePublishHelper {
         this.client = (AmazonS3Client)buildClient(
             s3.getAccessKey(), s3.getSecretKey(), s3.getSessionToken(),
             s3.getRegion(),
-            s3.getServiceEndpoint(), s3.getSigningRegion()
+            s3.getServiceEndpoint(), s3.getSigningRegion(),
+            s3.isPathStyleAccess()
         );
 
         this.bucket = s3.getBucket().toLowerCase();

--- a/appender-core/src/main/java/com/van/logging/elasticsearch/ElasticsearchPublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/elasticsearch/ElasticsearchPublishHelper.java
@@ -2,17 +2,19 @@ package com.van.logging.elasticsearch;
 
 import com.van.logging.IPublishHelper;
 import com.van.logging.PublishContext;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.*;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import com.van.logging.Event;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
-import java.net.InetAddress;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
@@ -24,40 +26,52 @@ public class ElasticsearchPublishHelper implements IPublishHelper<Event> {
 
     private final ElasticsearchConfiguration configuration;
 
-    private TransportClient transport;
-    private BulkRequestBuilder builder;
+    private final List<Node> nodes = new ArrayList<>();
+    private RestHighLevelClient client;
+    private BulkRequest bulkRequest;
     private int offset;
     private Date timeStamp;
 
     public ElasticsearchPublishHelper(ElasticsearchConfiguration configuration) {
         this.configuration = configuration;
+        this.configuration.iterateHosts((host, port) -> {
+            nodes.add(createNodeFromHost(host, port));
+        });
     }
 
-    private TransportClient getTransportClient(ElasticsearchConfiguration config) {
-        Settings settings = Settings.builder()
-            .put("cluster.name", config.getClusterName())
-            .build();
-        final PreBuiltTransportClient client = new PreBuiltTransportClient(settings);
-        config.iterateHosts((host, port) -> {
-            try {
-                client.addTransportAddress(
-                    new InetSocketTransportAddress(InetAddress.getByName(host), port)
-                );
-            } catch (Exception e) {
-                System.err.println(String.format(
-                    "Cannot add Elasticsearch host %s(%d): %s",
-                    host, port, e.getMessage()));
+    Node createNodeFromHost(String host, int port) {
+        String scheme = null;
+        String hostName = host.toLowerCase().trim();
+        if (hostName.startsWith("http:") || hostName.startsWith("https:")) {
+            String[] schemeAndHostname = hostName.split(":");
+            if (schemeAndHostname.length >= 2) {
+                scheme = schemeAndHostname[0];
+                hostName = schemeAndHostname[1];
             }
-        });
-        return client;
+        }
+        return new Node(new HttpHost(hostName, port, scheme));
     }
 
     @Override
     public void start(PublishContext context) {
         offset = 0;
         timeStamp = new Date();
-        transport = getTransportClient(this.configuration);
-        builder = transport.prepareBulk();
+
+        // The way RestClient.builder(Node... hosts) is designed requires hard-coding the list of hosts (great
+        // for demo programs but not for anything more serious).
+        // Because our host list is materialized from configuration as an array/list, we have to actually call
+        // RestClient.builder(Node... hosts) with an array via inflection. All this BS would not be necessary
+        // if they had just added a RestClient.builder(Node[] nodes) or RestClient.builder(Collection<Node> nodes).
+        try {
+            Method restClientBuilderMethod = RestClient.class.getDeclaredMethod("builder", Node[].class);
+            restClientBuilderMethod.setAccessible(true);
+            RestClientBuilder builder =
+                (RestClientBuilder)restClientBuilderMethod.invoke(null, new Object[]{nodes.toArray(new Node[0])});
+            client = new RestHighLevelClient(builder);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        bulkRequest = new BulkRequest();
     }
 
     @Override
@@ -76,27 +90,33 @@ public class ElasticsearchPublishHelper implements IPublishHelper<Event> {
                 .field("message", event.getMessage())
                 .array("tags", context.getTags())
                 .endObject();
-            builder.add(transport.prepareIndex(configuration.getIndex(), configuration.getType(), id)
-                .setSource(contentBuilder));
+            bulkRequest.add(new IndexRequest(configuration.getIndex()).id(id).source(contentBuilder));
             offset++;
         } catch (Exception ex) {
-            System.err.println(String.format("Cannot publish event: %s", ex.getMessage()));
+            System.err.printf("Cannot publish event: %s%n", ex.getMessage());
         }
     }
 
     @Override
     public void end(PublishContext context) {
         try {
-            if (null != builder) {
-                BulkResponse response = builder.get();
+            if ((null != client) && (null != bulkRequest)) {
+                BulkResponse response = client.bulk(bulkRequest, RequestOptions.DEFAULT);
                 if (response.hasFailures()) {
                     System.err.println("Elasticsearch publish failures: " + response.buildFailureMessage());
                 }
             }
+        } catch (IOException ex) {
+            ex.printStackTrace();
         } finally {
-            builder = null;
-            transport.close();
-            transport = null;
+            try {
+                if (null != client) {
+                    client.close();
+                }
+                bulkRequest = null;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 }

--- a/appender-core/src/test/java/com/van/logging/aws/AwsClientHelpersTest.java
+++ b/appender-core/src/test/java/com/van/logging/aws/AwsClientHelpersTest.java
@@ -50,6 +50,7 @@ public class AwsClientHelpersTest {
         PowerMock.mockStaticPartial(AwsClientHelpers.class, "getS3ClientBuilder");
         EasyMock.expect(AwsClientHelpers.getS3ClientBuilder()).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.withCredentials(anyObject())).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withPathStyleAccessEnabled(false)).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.withRegion(region.getName())).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.build()).andReturn(mockedClient);
         PowerMock.replayAll();
@@ -82,6 +83,7 @@ public class AwsClientHelpersTest {
         PowerMock.mockStaticPartial(AwsClientHelpers.class, "getS3ClientBuilder");
         EasyMock.expect(AwsClientHelpers.getS3ClientBuilder()).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.withCredentials(anyObject())).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withPathStyleAccessEnabled(false)).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.withEndpointConfiguration(
             anyObject(AwsClientBuilder.EndpointConfiguration.class
         ))).andReturn(mockedS3ClientBuilder);

--- a/appender-core/src/test/java/com/van/logging/aws/AwsClientHelpersTest.java
+++ b/appender-core/src/test/java/com/van/logging/aws/AwsClientHelpersTest.java
@@ -8,6 +8,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,10 +18,11 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.easymock.EasyMock.anyObject;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({AwsClientHelpers.class})
+@PrepareForTest({AwsClientHelpers.class, AmazonS3ClientBuilder.class})
 public class AwsClientHelpersTest {
 
     String accessKey;
@@ -44,9 +46,10 @@ public class AwsClientHelpersTest {
          *  Tests that the region is set on the client builder before the client is built.
          */
         AmazonS3 mockedClient = PowerMock.createMock(AmazonS3.class);
-        AwsClientBuilder mockedS3ClientBuilder = PowerMock.createMock(AwsClientBuilder.class);
+        AmazonS3ClientBuilder mockedS3ClientBuilder = PowerMock.createMock(AmazonS3ClientBuilder.class);
         PowerMock.mockStaticPartial(AwsClientHelpers.class, "getS3ClientBuilder");
         EasyMock.expect(AwsClientHelpers.getS3ClientBuilder()).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withCredentials(anyObject())).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.withRegion(region.getName())).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.build()).andReturn(mockedClient);
         PowerMock.replayAll();
@@ -54,7 +57,8 @@ public class AwsClientHelpersTest {
         try {
             AmazonS3 client = AwsClientHelpers.buildClient(
                 accessKey, secretKey, null, region,
-                null, null
+                null, null,
+                false
             );
             assertEquals(mockedClient, client);
 
@@ -74,19 +78,56 @@ public class AwsClientHelpersTest {
          *  Tests that the service endpoint and signing region are set on the client builder before the client is built.
          */
         AmazonS3 mockedClient = PowerMock.createMock(AmazonS3.class);
-        AwsClientBuilder mockedS3ClientBuilder = PowerMock.createMock(AwsClientBuilder.class);
+        AmazonS3ClientBuilder mockedS3ClientBuilder = PowerMock.createMock(AmazonS3ClientBuilder.class);
         PowerMock.mockStaticPartial(AwsClientHelpers.class, "getS3ClientBuilder");
         EasyMock.expect(AwsClientHelpers.getS3ClientBuilder()).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withCredentials(anyObject())).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.withEndpointConfiguration(
-            new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, signingRegion)
-        )).andReturn(mockedS3ClientBuilder);
+            anyObject(AwsClientBuilder.EndpointConfiguration.class
+        ))).andReturn(mockedS3ClientBuilder);
         EasyMock.expect(mockedS3ClientBuilder.build()).andReturn(mockedClient);
         PowerMock.replayAll();
 
         try {
             AmazonS3 client = AwsClientHelpers.buildClient(
                 accessKey, secretKey, null, null,
-                serviceEndpoint, signingRegion
+                serviceEndpoint, signingRegion,
+                false
+            );
+            assertEquals(mockedClient, client);
+
+            // Not verifying AwsClientHelpers.class due to some odd behavior not related to the test.
+            // Maybe related to https://stackoverflow.com/questions/21690492/using-easymock-with-recursive-method
+            // but not gonna spend time on this right now since it's not relevant to the test.
+            PowerMock.verify(mockedClient, mockedS3ClientBuilder);
+
+        } catch (Exception ex) {
+            fail("Unexpected exception: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testBuildClientWithPathStyleAccess() {
+        /**
+         *  Tests that the pathStyleAccess option is set on the client builder before the client is built.
+         */
+        AmazonS3 mockedClient = PowerMock.createMock(AmazonS3.class);
+        AmazonS3ClientBuilder mockedS3ClientBuilder = PowerMock.createMock(AmazonS3ClientBuilder.class);
+        PowerMock.mockStaticPartial(AwsClientHelpers.class, "getS3ClientBuilder");
+        EasyMock.expect(AwsClientHelpers.getS3ClientBuilder()).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withCredentials(anyObject())).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withPathStyleAccessEnabled(true)).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.withEndpointConfiguration(
+            anyObject(AwsClientBuilder.EndpointConfiguration.class
+            ))).andReturn(mockedS3ClientBuilder);
+        EasyMock.expect(mockedS3ClientBuilder.build()).andReturn(mockedClient);
+        PowerMock.replayAll();
+
+        try {
+            AmazonS3 client = AwsClientHelpers.buildClient(
+                accessKey, secretKey, null, null,
+                serviceEndpoint, signingRegion,
+                true
             );
             assertEquals(mockedClient, client);
 

--- a/appender-log4j/pom.xml
+++ b/appender-log4j/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <properties>
-        <powermock.version>1.6.6</powermock.version>
+        <powermock.version>2.0.9</powermock.version>
     </properties>
 
     <dependencies>
@@ -153,9 +153,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/appender-log4j/pom.xml
+++ b/appender-log4j/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j</artifactId>
-    <version>2.8.5-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>appender-log4j</name>
     <description>Core functionality to send content to various channels using Log4j 1.x</description>
     <packaging>jar</packaging>
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>2.8.4</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>2.8.4</version>
+            <version>3.0.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
+++ b/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
@@ -190,6 +190,10 @@ public class Log4jAppender extends AppenderSkeleton
         }
     }
 
+    public void setS3PathStyleAccess(String pathStyleAccess) {
+        getS3Configuration().setPathStyleAccess(Boolean.parseBoolean(pathStyleAccess));
+    }
+
     // Azure blob properties
     ///////////////////////////////////////////////////////////////////////////
     private BlobConfiguration getBlobConfiguration() {

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <properties>
-        <powermock.version>1.6.6</powermock.version>
+        <powermock.version>2.0.9</powermock.version>
     </properties>
 
     <dependencies>
@@ -153,9 +153,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>2.8.5-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Core functionality to send content to various channels using Log4j 2.7+</description>
     <packaging>jar</packaging>
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>2.8.4</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>2.8.4</version>
+            <version>3.0.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -71,6 +71,9 @@ public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appende
     @PluginBuilderAttribute
     private String s3CannedAcl;
 
+    @PluginBuilderAttribute
+    private boolean s3PathStyleAccess;
+
     // Azure blob properties
     @PluginBuilderAttribute
     private String azureStorageConnectionString;
@@ -154,6 +157,7 @@ public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appende
             config.setSessionToken(s3AwsSessionToken);
             config.setServiceEndpoint(s3ServiceEndpoint);
             config.setSigningRegion(s3SigningRegion);
+            config.setPathStyleAccess(s3PathStyleAccess);
             if (StringUtils.isTruthy(s3CannedAcl)) {
                 try {
                     config.setCannedAclFromValue(s3CannedAcl);

--- a/misc/elasticsearch/logindex.json
+++ b/misc/elasticsearch/logindex.json
@@ -1,6 +1,5 @@
 {
   "mappings":{
-    "_doc":{
       "properties":{
         "hostname":{
           "type":"keyword"
@@ -30,5 +29,4 @@
         }
       }
     }
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>8</source>
+                        <target>8</target>
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>2.8.5-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>log4j-s3-search</name>
     <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -46,24 +46,24 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
-                <version>1.11.613</version>
+                <version>1.11.964</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-storage</artifactId>
-                <version>8.6.3</version>
+                <version>8.6.6</version>
             </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-storage</artifactId>
-                <version>1.106.0</version>
+                <version>1.113.11</version>
             </dependency>
 
             <!-- Search -->
             <dependency>
                 <groupId>org.apache.solr</groupId>
                 <artifactId>solr-solrj</artifactId>
-                <version>6.6.6</version>
+                <version>8.8.1</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
@@ -91,7 +91,7 @@
                          org.apache.maven.plugins ...which is assumed by default.
                      -->
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.3.0</version>
                     <configuration>
                         <descriptorRefs>
                             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -115,7 +115,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>3.0.0-M1</version>
                     <configuration>
                         <localCheckout>true</localCheckout>
                         <pushChanges>false</pushChanges>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
-                <artifactId>transport</artifactId>
-                <version>5.6.16</version>
+                <artifactId>elasticsearch-rest-high-level-client</artifactId>
+                <version>7.11.1</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Major version bump **3.0.0**:
* JDK 11 (or higher?) is now the prerequisite JDK version
* Upgraded version of various dependencies and plugins
* Migrated `ElasticsearchPublishHelper `to now use Elasticsearch's high-level REST client instead of the deprecated Transport client (tested with Elasticsearch 7.11.1)