### PR TITLE
Adding hook to inject custom publish helper for ES

### DIFF
--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/appender-core/src/main/java/com/van/logging/elasticsearch/IElasticsearchPublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/elasticsearch/IElasticsearchPublishHelper.java
@@ -1,0 +1,19 @@
+package com.van.logging.elasticsearch;
+
+
+import com.van.logging.Event;
+import com.van.logging.IPublishHelper;
+
+
+/**
+ * Interface for implementations of an IPublishHelper to publish events to Elasticsearch.
+ */
+public interface IElasticsearchPublishHelper extends IPublishHelper<Event> {
+
+    /**
+     * Initialize the publish helper immediately after construction
+     *
+     * @param configuration configuration information to initialize the publish helper with
+     */
+    public void initialize(ElasticsearchConfiguration configuration);
+}

--- a/appender-log4j/pom.xml
+++ b/appender-log4j/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
+++ b/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
@@ -95,6 +95,7 @@ public class Log4jAppender extends AppenderSkeleton
     private CloudStorageConfiguration cloudStorageConfiguration;
     private SolrConfiguration solr;
     private ElasticsearchConfiguration elasticsearchConfiguration;
+    private String elasticsearchHelperClassName;
 
     private boolean verbose = false;
 
@@ -281,6 +282,12 @@ public class Log4jAppender extends AppenderSkeleton
         elasticsearchConfiguration.setType(type);
     }
 
+    public void setElasticSearchPublishHelperClass(String className) {
+        elasticsearchHelperClassName = className;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
 
     public void setTags(String tags) {
         if (null != tags) {
@@ -390,7 +397,10 @@ public class Log4jAppender extends AppenderSkeleton
             if (verbose) {
                 System.out.println("Registering Elasticsearch publish helper");
             }
-            publisher.addHelper(new ElasticsearchPublishHelper(elasticsearchConfiguration));
+            publisher.addHelper(
+                ElasticsearchPublishHelper.getPublishHelper(
+                    elasticsearchHelperClassName, elasticsearchConfiguration, Log4jAppender.class.getClassLoader())
+            );
         }
         return publisher;
     }

--- a/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
+++ b/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
@@ -7,6 +7,7 @@ import com.van.logging.azure.BlobConfiguration;
 import com.van.logging.azure.BlobPublishHelper;
 import com.van.logging.elasticsearch.ElasticsearchConfiguration;
 import com.van.logging.elasticsearch.ElasticsearchPublishHelper;
+import com.van.logging.elasticsearch.IElasticsearchPublishHelper;
 import com.van.logging.gcp.CloudStorageConfiguration;
 import com.van.logging.gcp.CloudStoragePublishHelper;
 import com.van.logging.solr.SolrConfiguration;
@@ -397,10 +398,11 @@ public class Log4jAppender extends AppenderSkeleton
             if (verbose) {
                 System.out.println("Registering Elasticsearch publish helper");
             }
-            publisher.addHelper(
-                ElasticsearchPublishHelper.getPublishHelper(
-                    elasticsearchHelperClassName, elasticsearchConfiguration, Log4jAppender.class.getClassLoader())
-            );
+
+            IElasticsearchPublishHelper helper = ElasticsearchPublishHelper.getPublishHelper(
+                elasticsearchHelperClassName, Log4jAppender.class.getClassLoader());
+            helper.initialize(elasticsearchConfiguration);
+            publisher.addHelper(helper);
         }
         return publisher;
     }

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -7,6 +7,7 @@ import com.van.logging.azure.BlobConfiguration;
 import com.van.logging.azure.BlobPublishHelper;
 import com.van.logging.elasticsearch.ElasticsearchConfiguration;
 import com.van.logging.elasticsearch.ElasticsearchPublishHelper;
+import com.van.logging.elasticsearch.IElasticsearchPublishHelper;
 import com.van.logging.gcp.CloudStorageConfiguration;
 import com.van.logging.gcp.CloudStoragePublishHelper;
 import com.van.logging.solr.SolrConfiguration;
@@ -21,7 +22,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appender.AbstractAppender.Builder
+public class Log4j2AppenderBuilder<B extends Log4j2AppenderBuilder<B>>
+    extends org.apache.logging.log4j.core.appender.AbstractAppender.Builder<B>
     implements org.apache.logging.log4j.core.util.Builder<Log4j2Appender> {
 
     // general properties
@@ -119,7 +121,6 @@ public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appende
 
 
     @Override
-    @SuppressWarnings("unchecked")
     public Log4j2Appender build() {
         try {
             String cacheName = UUID.randomUUID().toString().replaceAll("-","");
@@ -282,10 +283,10 @@ public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appende
                 System.out.println(String.format(
                     "Registering Elasticsearch publish helper -> %s", config));
             }
-            publisher.addHelper(
-                ElasticsearchPublishHelper.getPublishHelper(
-                    elasticSearchPublishHelperClass, config, Log4j2AppenderBuilder.class.getClassLoader())
-            );
+            IElasticsearchPublishHelper helper = ElasticsearchPublishHelper.getPublishHelper(
+                elasticSearchPublishHelperClass, Log4j2AppenderBuilder.class.getClassLoader());
+            helper.initialize(config);
+            publisher.addHelper(helper);
         });
 
         return publisher;

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -114,6 +114,9 @@ public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appende
     @PluginBuilderAttribute
     private String elasticsearchHosts;
 
+    @PluginBuilderAttribute
+    private String elasticSearchPublishHelperClass;
+
 
     @Override
     @SuppressWarnings("unchecked")
@@ -279,7 +282,10 @@ public class Log4j2AppenderBuilder extends org.apache.logging.log4j.core.appende
                 System.out.println(String.format(
                     "Registering Elasticsearch publish helper -> %s", config));
             }
-            publisher.addHelper(new ElasticsearchPublishHelper(config));
+            publisher.addHelper(
+                ElasticsearchPublishHelper.getPublishHelper(
+                    elasticSearchPublishHelperClass, config, Log4j2AppenderBuilder.class.getClassLoader())
+            );
         });
 
         return publisher;


### PR DESCRIPTION
This is a experimental approach to allow clients to inject their own implementation of the Elasticsearch publish helper (and probably a basis for a general plug-in mechanism for custom publish helpers in the future).

Impetus is https://github.com/bluedenim/log4j-s3-search/issues/90 where there is a need to tweak the format of message sent to Elasticsearch when indexing.
