### PR TITLE
3.6.0: bump log4j2; shutdown fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## IMPORTANT NOTE on log4j vulnerabilty: https://www.cisa.gov/news/2021/12/11/statement-cisa-director-easterly-log4j-vulnerability
 
-* log4j-s3-search Release **3.5.0** was built with **log4j2 2.17.0**, addressing recent vulnerabilities (see above). You are **strongly advised** to also switch to Log4j2 2.17.0 **or higher** for your applications.
-* **PLEASE consider upgrading from Log4j 1.x to Log4j 2.x (particularly 2.17.0+)**. Log4j 1.x is deprecated, and there are vulnerabilities with it that nobody will fix.
+* log4j-s3-search Release **3.6.0** is built with **log4j2 2.17.1**, addressing recent vulnerabilities (see above). You are **strongly advised** to also switch to Log4j2 2.17.1 (**or [higher](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core)**, since I'm tired of updating this) for your applications.
+* If you're still using Log4j 1,x, **PLEASE consider upgrading to Log4j 2.x**. Log4j 1.x is deprecated, and _there are vulnerabilities with it that nobody will fix_. Once I get around to it, I may even drop **appender-log4j** from this repo.
 
 ![](misc/log4j-s3-search.png)
 

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>3.5.1-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <name>appender-core</name>
     <description>Core functionality to send content to various channels, used by appender-log4j and appender-log4j2</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>

--- a/appender-log4j/pom.xml
+++ b/appender-log4j/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j</artifactId>
-    <version>3.5.1-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <name>appender-log4j</name>
     <description>Log4j 1.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>

--- a/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
+++ b/appender-log4j/src/main/java/com/van/logging/log4j/Log4jAppender.java
@@ -359,10 +359,21 @@ public class Log4jAppender extends AppenderSkeleton
 
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 public void run() {
+                if (verbose) {
+                    System.out.println("Publishing staging log on shutdown...");
+                }
+                stagingLog.flushAndPublish(true);
+                try {
                     if (verbose) {
-                        System.out.println("Publishing staging log on shutdown...");
+                        System.out.println("Shutting down LoggingEventCache...");
                     }
-                    stagingLog.flushAndPublish(true);
+                    LoggingEventCache.shutDown();
+                } catch (InterruptedException e) {
+                    if (verbose) {
+                        System.out.println("InterruptedException during LoggingEventCache.shutDown");
+                        e.printStackTrace(System.out);
+                    }
+                }
                 }
             });
         }

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>3.5.1-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Log4j 2.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
 
         <dependency>

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -135,9 +135,11 @@ public class Log4j2AppenderBuilder
             String cacheName = UUID.randomUUID().toString().replaceAll("-","");
             LoggingEventCache<Event> cache = new LoggingEventCache<>(
                 cacheName, createCacheMonitor(), createCachePublisher(), verbose);
-            return installFilter(new Log4j2Appender(
-                    getName(), getFilter(), getLayout(),
-                    true, cache));
+            Log4j2Appender appender = new Log4j2Appender(
+                getName(), getFilter(), getLayout(),
+                true, cache);
+            appender.setVerbose(verbose);
+            return installFilter(appender);
         } catch (Exception e) {
             throw new RuntimeException("Cannot build appender due to errors", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>3.5.1-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <name>log4j-s3-search</name>
     <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>


### PR DESCRIPTION
* Bump Log4j2 to 2.17.1 (last time hopefully?)
* Add call to `LoggingEventCache.shutDown` in shutdown hooks
