### PR TITLE
Add support of AWS S3 Storage Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Content configurations
 * **s3Compression** -- if set to "true," then contents will be GZIP'ed before publishing into S3
 * **s3KeyGzSuffixEnabled** -- if set to "true," then the s3 key will have a `.gz` suffix when `s3Compression` is enabled. (If `s3Compression` is not "true," this is ignored.)  
 * **s3SseKeyType** -- if set to "SSE_S3," then contents published will be flagged to use SSE-S3 encryption (see https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)
+* **s3StorageClass** -- the S3 storage class associated with sent objects (e.g. "standard", "glacier"), if not set then "standard" storage class will be used as default (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html)
 
 ### Azure Blob
 These properties (**please use your own values**) control how the logs will be stored in Azure Blob Storage:

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>3.6.0-SNAPSHOT</version>
+    <version>3.7.0-SNAPSHOT</version>
     <name>appender-core</name>
     <description>Core functionality to send content to various channels, used by appender-log4j and appender-log4j2</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>3.5.0</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/appender-core/src/main/java/com/van/logging/aws/S3Configuration.java
+++ b/appender-core/src/main/java/com/van/logging/aws/S3Configuration.java
@@ -3,6 +3,7 @@ package com.van.logging.aws;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.StorageClass;
 import com.van.logging.utils.StringUtils;
 
 /**
@@ -63,6 +64,8 @@ public class S3Configuration {
     private S3SSEConfiguration sseConfiguration = null;
 
     private CannedAccessControlList cannedAcl = null;
+
+    private StorageClass storageClass = null;
 
     public String getAccessKey() {
         return accessKey;
@@ -164,6 +167,19 @@ public class S3Configuration {
         this.keyGzSuffixEnabled = gzSuffix;
     }
 
+    public StorageClass getStorageClass() { return this.storageClass; }
+
+    /**
+     * Sets the storage class to use when creating the S3 PutObjectRequest. The value can be the
+     * "uppercase underscore" format (e.g. "STANDARD", "DEEP_ARCHIVE")
+     * or the StorageClass enum ordinal name (e.g. "Standard" or "Glacier").
+     * <br>
+     * If the value is <code>null</code>, then no storage class will be explicitly set.
+     *
+     * @param storageClassName the storage class name (e.g. "standard", "glacier")
+     */
+    public void setStorageClass(String storageClassName) { this.storageClass = resolveStorageClass(storageClassName); }
+
     /**
      * Best-effort to map a region name to an actual Region instance. The input
      * string can be either the public region name (e.g. "us-west-1") or the
@@ -191,6 +207,32 @@ public class S3Configuration {
         }
         return region;
     }
+
+    /**
+     * Best-effort to map a storage class name to an actual StorageClass instance. The input
+     * string can be either the public storage class value (e.g. "STANDARD") or the
+     * StorageClass enum ordinal name (e.g. "Standard").
+     *
+     * @param str the storage class name to map to a StorageClass
+     *
+     * @return the mapped StorageClass
+     *
+     * @throws IllegalArgumentException if the input name cannot be mapped to a
+     *  StorageClass.
+     */
+    static StorageClass resolveStorageClass(String str) {
+        if (StringUtils.isTruthy(str)) {
+            try {
+                return StorageClass.valueOf(str);
+            } catch (IllegalArgumentException ex) {
+                // Try to interpret as the public value (this is more expensive). If
+                // this fails, then just propagate the IllegalArgumentException out.
+                return StorageClass.fromValue(str);
+            }
+        }
+        return null;
+    }
+
 
     public String toString() {
         if (StringUtils.isTruthy(this.path)) {

--- a/appender-core/src/main/java/com/van/logging/aws/S3PublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/aws/S3PublishHelper.java
@@ -1,10 +1,7 @@
 package com.van.logging.aws;
 
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.*;
 import com.van.logging.AbstractFilePublishHelper;
 import com.van.logging.IStorageDestinationAdjuster;
 import com.van.logging.PublishContext;
@@ -41,6 +38,7 @@ public class S3PublishHelper extends AbstractFilePublishHelper {
     private final IStorageDestinationAdjuster storageDestinationAdjuster;
     private final boolean isCompressionEnabled;
     private final boolean keyGzSuffix;
+    private final StorageClass storageClass;
 
     private volatile boolean bucketExists = false;
 
@@ -63,6 +61,7 @@ public class S3PublishHelper extends AbstractFilePublishHelper {
         this.cannedAcl = s3.getCannedAcl();
         this.isCompressionEnabled = s3.isCompressionEnabled();
         this.keyGzSuffix = s3.isKeyGzSuffixEnabled();
+        this.storageClass = s3.getStorageClass();
     }
 
     @Override
@@ -114,11 +113,11 @@ public class S3PublishHelper extends AbstractFilePublishHelper {
                 metadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
             }
 
-            PutObjectRequest por;
-            if (cannedAcl != null)
-                por = new PutObjectRequest(bucket, key, file).withCannedAcl(cannedAcl);
-            else
-                por = new PutObjectRequest(bucket, key, file);
+            final PutObjectRequest por = new PutObjectRequest(bucket, key, file);
+
+            if (cannedAcl != null) por.setCannedAcl(cannedAcl);
+            if (storageClass != null) por.setStorageClass(storageClass);
+
             por.setMetadata(metadata);
 
             PutObjectResult result = client.putObject(por);

--- a/appender-log4j/pom.xml
+++ b/appender-log4j/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j</artifactId>
-    <version>3.6.0-SNAPSHOT</version>
+    <version>3.7.0-SNAPSHOT</version>
     <name>appender-log4j</name>
     <description>Log4j 1.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>3.5.0</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>3.5.0</version>
+            <version>3.7.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>3.6.0-SNAPSHOT</version>
+    <version>3.7.0-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Log4j 2.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>3.5.0</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>3.5.0</version>
+            <version>3.7.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -79,6 +79,9 @@ public class Log4j2AppenderBuilder
     @PluginBuilderAttribute
     private boolean s3PathStyleAccess;
 
+    @PluginBuilderAttribute
+    private String s3StorageClass;
+
     // Azure blob properties
     @PluginBuilderAttribute
     private String azureStorageConnectionString;
@@ -191,6 +194,8 @@ public class Log4j2AppenderBuilder
                 );
             }
             config.setSseConfiguration(sseConfig);
+            config.setStorageClass(s3StorageClass);
+
             s3Config = Optional.of(config);
         }
         return s3Config;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>3.6.0-SNAPSHOT</version>
+    <version>3.7.0-SNAPSHOT</version>
     <name>log4j-s3-search</name>
     <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>


### PR DESCRIPTION
I made some changes to make it possible to configure the storage class that will be attached to every sent file. 

In my case, it will prevent from a redundant `life cycle rule` that transits objects from `standard` storage class to `glacier` storage class after one day (minimal time needed to perform transitions).

Kindly review. Please, suggest some tips if something looks bad.