### PR TITLE
release log4j-s3-search-4.0.0

### DIFF
--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <name>appender-core</name>
-    <description>Core functionality to send content to various channels, used by appender-log4j and appender-log4j2</description>
+    <description>Core functionality to send content to various channels, used by appender-log4j2</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <properties>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Log4j 2.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>3.7.0</version>
+            <version>4.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <name>log4j-s3-search</name>
     <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>


### PR DESCRIPTION
* Removal of appender-log4j
* Dependencies updates
* Elasticsearch configuration's `elasticsearchHosts`  supports scheme/protocol (e.g. `https://localhost:9200`)
* Readme updates