### PR TITLE
Instructions and config files to enable Docker containers for Solr and Elasticsearch test servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target
 *.iml
 *~
 dependency-reduced-pom.xml
+
+misc/solr/data
+misc/solr/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM adoptopenjdk/openjdk11:latest
+WORKDIR /code
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/code
+    networks:
+      - network
+    tty: true
+    stdin_open: true
+  solr:
+    image: solr:8.11.2
+    volumes:
+      - ${SOLR_CORE_DIR}:/var/solr
+    ports:
+      - "8983:8983"
+    expose:
+      - "8983"
+    networks:
+      - network
+    command:
+      - solr-precreate
+      - log4js3
+  elasticsearch:
+    image: elasticsearch:7.17.6
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    expose:
+      - "9200"
+      - "9300"
+    networks:
+      - network
+networks:
+  # Declare our private network.  We must declare one for the magic
+  # Docker DNS to work, but otherwise its default settings are fine.
+  network: {
+    driver: bridge
+  }

--- a/misc/elasticsearch/README.md
+++ b/misc/elasticsearch/README.md
@@ -1,0 +1,22 @@
+### Elasticsearch Test Configuration
+
+This subdirectory has a `logindex.json` that can be used to 
+initialize an index on an Elasticsearch server.
+
+To use the test configuration in this repo:
+
+* Bring up the server:
+  ```
+  docker-compose up elasticsearch
+  ```
+* Ensure you get a response from http://localhost:9200/
+* Use `curl` or similar tool to create the index **log4js3** with the file `logindex.json`. E.g.
+  ```
+  curl -XPUT --header "Content-Type:application/json" -d "@logindex.json" http://localhost:9200/log4js3
+  ```
+  
+  You may use a different index name than "log4js3," of course.
+* Verify index is created successfully by checking http://localhost:9200/log4js3/_search
+* You can now send logs to the index hosted on the local server at http://localhost:9200.
+* You can take a look at https://github.com/bluedenim/log4j-s3-search-samples/blob/master/appender-log4j2-sample/src/main/resources/log4j2.xml#L59-L64 
+  to see how to configure a program to send logs to it.

--- a/misc/solr/README.md
+++ b/misc/solr/README.md
@@ -1,0 +1,17 @@
+### Solr Test Configuration
+
+This subdirectory has configuration files set up so that it can
+be mapped to a volume at `/var/solr` to get the Docker instance
+of Solr to use.
+
+To use this:
+* Make sure **docker-compose** is at version **1.5+**
+* Set the environment variable `SOLR_CORE_DIR` to this directory
+  on the file system (e.g. `~/proj/log4j-s3-search/misc/solr`)
+* Start the Solr container:
+  ```
+  docker-compose up solr
+  ```
+* The Solr server will be accessible at http://localhost:8983/solr/#/
+* You can take a look at https://github.com/bluedenim/log4j-s3-search-samples/blob/master/appender-log4j2-sample/src/main/resources/log4j2.xml#L55-L56
+  to see how to configure a program to send logs to it.

--- a/misc/solr/log4j2.xml
+++ b/misc/solr/log4j2.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!-- Default production configuration is asnychronous logging -->
+<Configuration>
+  <Appenders>
+
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout>
+        <Pattern>
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+        </Pattern>
+      </PatternLayout>
+    </Console>
+
+    <RollingRandomAccessFile
+        name="MainLogFile"
+        fileName="${sys:solr.log.dir}/solr.log"
+        filePattern="${sys:solr.log.dir}/solr.log.%i" >
+      <PatternLayout>
+        <Pattern>
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+        </Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="32 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingRandomAccessFile>
+
+    <RollingRandomAccessFile
+        name="SlowLogFile"
+        fileName="${sys:solr.log.dir}/solr_slow_requests.log"
+        filePattern="${sys:solr.log.dir}/solr_slow_requests.log.%i" >
+      <PatternLayout>
+        <Pattern>
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+        </Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="32 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingRandomAccessFile>
+
+  </Appenders>
+  <Loggers>
+    <!-- Use <AsyncLogger/<AsyncRoot and <Logger/<Root for asynchronous logging or synchonous logging respectively -->
+    <AsyncLogger name="org.apache.hadoop" level="warn"/>
+    <AsyncLogger name="org.apache.solr.update.LoggingInfoStream" level="off"/>
+    <AsyncLogger name="org.apache.zookeeper" level="warn"/>
+    <!-- HttpSolrCall adds markers denoting the handler class to allow fine grained control, metrics are
+         very noisy so by default the metrics handler is turned off to see metrics logging set DENY to ACCEPT -->
+    <AsyncLogger name="org.apache.solr.servlet.HttpSolrCall" level="info">
+      <MarkerFilter marker="org.apache.solr.handler.admin.MetricsHandler" onMatch="DENY" onMismatch="ACCEPT"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.apache.solr.core.SolrCore.SlowRequest" level="info" additivity="false">
+      <AppenderRef ref="SlowLogFile"/>
+    </AsyncLogger>
+
+    <AsyncRoot level="info">
+      <AppenderRef ref="MainLogFile"/>
+      <AppenderRef ref="STDOUT"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>
+

--- a/misc/solr/schema.xml
+++ b/misc/solr/schema.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" ?>
 <schema name="S3 logger schema" version="1.1">
    <fieldtype name="string"  class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-   <fieldtype name="tdate"  class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
-   <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
+   <fieldtype name="pdates"  class="solr.DatePointField" />
+   <fieldType name="plongs" class="solr.LongPointField" />
+   <fieldType name="pdoubles" class="solr.DoublePointField" />
+   <fieldType name="booleans" class="solr.BoolField" />
    <!-- A text field with defaults appropriate for English: it
      tokenizes with StandardTokenizer, removes English stop words
      (lang/stopwords_en.txt), down cases, protects words from protwords.txt, and
      finally applies Porter's stemming.  The query time analyzer
      also applies synonyms from synonyms.txt. -->
-   <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+   <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- in this example, we will only use synonyms at query time
@@ -21,7 +23,6 @@
         <filter class="solr.StopFilterFactory"
             ignoreCase="true"
             words="lang/stopwords_en.txt"
-            enablePositionIncrements="true"
             />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -37,7 +38,6 @@
         <filter class="solr.StopFilterFactory"
             ignoreCase="true"
             words="lang/stopwords_en.txt"
-            enablePositionIncrements="true"
             />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -51,18 +51,18 @@
 
    <!-- general -->
    <field name="id"          type="string"   indexed="true"  stored="true"  multiValued="false" required="true"/>
-   <field name="timestamp"   type="tdate"    indexed="true"  stored="true"  multiValued="false" />
+   <field name="timestamp"   type="pdates"    indexed="true"  stored="true"  multiValued="false" />
    <field name="type"        type="string"   indexed="true"  stored="true"  multiValued="false" />
    <field name="hostname"    type="string"   indexed="true"  stored="true"  multiValued="false" />
-   <field name="offset"      type="long"     indexed="false" stored="true" />
+   <field name="offset"      type="plongs"     indexed="false" stored="true" />
    <field name="thread_name" type="string"   indexed="true"  stored="true"  multiValued="false" />
    <field name="logger"      type="string"   indexed="true"  stored="true"  multiValued="false" />
-   <field name="message"     type="text_en"  indexed="true"  stored="true"  multiValued="false" />
+   <field name="message"     type="text_general"  indexed="true"  stored="true"  multiValued="false" />
    <field name="tags"        type="string"   indexed="true"  stored="true"  multiValued="true" />
-   <field name="_version_"   type="long"     indexed="true"  stored="true" />
+   <field name="_version_"   type="plongs"     indexed="true"  stored="true" />
 
    <!--
-   <field name="catch_all"   type="text_en"  indexed="true"  stored="false"  multiValued="true" />
+   <field name="catch_all"   type="text_general"  indexed="true"  stored="false"  multiValued="true" />
    <copyField source="thread_name" dest="catch_all" />
    <copyField source="message" dest="catch_all" />
    -->
@@ -74,7 +74,4 @@
    <!--
    <defaultSearchField>catch_all</defaultSearchField>
    -->
-
-   <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-   <solrQueryParser defaultOperator="OR"/>
 </schema>


### PR DESCRIPTION
This will establish a repeatable setup for the two search test servers.

**Solr** will be available at http://localhost:8983/
**Elasticsearch** will be available at http://localhost:9200/
