### PR TITLE
Refactor internal logging to use a logger instead of System.out/System.err

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM adoptopenjdk/openjdk11:latest
-WORKDIR /code
-

--- a/README.md
+++ b/README.md
@@ -367,3 +367,29 @@ document to the S3 batch from which the corresponding log event can be found.
 String id = solrDoc.getFieldValue("id").toString();
 String s3Key = id.substring(0, id.indexOf("-"));
 ```
+
+## Logging from log4j-s3-search
+The appender and components of this library also logs events under the logger named "`com.van.logging.VansLogger`."
+To prevent logs of this logger from polluting the clients' logs, these logs will be ignored by the code 
+(`LoggingEventCache`) when forwarding to various log publishers.
+
+To see these logs (e.g. to debug), you can add a logger config to dump to console (or any other appender):
+```
+  <Appenders>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss,SSS} [%t] %-5p %c{36} - %m%n"/>
+    </Console>
+    ...
+  </Appenders>
+  
+  <Loggers>
+    <Logger name="com.van.logging" level="debug" additivity="false">
+      <AppenderRef ref="ConsoleAppender" />
+    </Logger>
+    ...
+  </Loggers>
+  ....
+```
+
+An example of this can be seen in the example repo 
+[log4j-s3-search-samples](https://github.com/bluedenim/log4j-s3-search-samples/blob/master/appender-log4j2-sample/src/main/resources/log4j2.xml#L73-L75).

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -71,6 +71,12 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>appender-core</name>
     <description>Core functionality to send content to various channels, used by appender-log4j2</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>4.1.0</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/appender-core/src/main/java/com/van/logging/AbstractFilePublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/AbstractFilePublishHelper.java
@@ -28,12 +28,12 @@ public abstract class AbstractFilePublishHelper implements IPublishHelper<Event>
             );
             outputWriter = new OutputStreamWriter(os);
             if (verbose) {
-                System.out.println(String.format("Collecting content into %s before uploading.", tempFile));
+                VansLogger.logger.debug(String.format("Collecting content into %s before uploading.", tempFile));
             }
 
         } catch (Exception ex) {
             if (verbose) {
-                ex.printStackTrace(System.out);
+                VansLogger.logger.error("Cannot start publish batch", ex);
             }
             throw new RuntimeException(String.format("Cannot start publishing: %s", ex.getMessage()), ex);
         }
@@ -45,7 +45,7 @@ public abstract class AbstractFilePublishHelper implements IPublishHelper<Event>
             outputWriter.write(event.getMessage());
         } catch (Exception ex) {
             if (verbose) {
-                ex.printStackTrace(System.out);
+                VansLogger.logger.error("Cannot publish batch", ex);
             }
             throw new RuntimeException(String.format("Cannot collect event %s: %s", event, ex.getMessage()), ex);
         }
@@ -61,7 +61,7 @@ public abstract class AbstractFilePublishHelper implements IPublishHelper<Event>
             publishFile(tempFile, context);
         } catch (Exception ex) {
             if (verbose) {
-                ex.printStackTrace(System.out);
+                VansLogger.logger.error("Cannot end publish batch", ex);
             }
             throw new RuntimeException(String.format("Cannot end publishing: %s", ex.getMessage()), ex);
         } finally {
@@ -82,7 +82,7 @@ public abstract class AbstractFilePublishHelper implements IPublishHelper<Event>
         Objects.requireNonNull(outputStream);
         if (compressEnabled) {
             if (verbose) {
-                System.out.println("Content will be compressed.");
+                VansLogger.logger.debug("Content will be compressed.");
             }
             return new GZIPOutputStream(outputStream);
         } else {

--- a/appender-core/src/main/java/com/van/logging/AbstractFilePublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/AbstractFilePublishHelper.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.Objects;
 import java.util.zip.GZIPOutputStream;
 
-public abstract class AbstractFilePublishHelper implements IPublishHelper<Event> {
+public abstract class AbstractFilePublishHelper implements IPublishHelper {
 
     private final boolean compressEnabled;
     protected final boolean verbose;

--- a/appender-core/src/main/java/com/van/logging/BufferPublisher.java
+++ b/appender-core/src/main/java/com/van/logging/BufferPublisher.java
@@ -12,11 +12,11 @@ import java.util.List;
  * @author vly
  *
  */
-public class BufferPublisher<T> implements IBufferPublisher<T> {
+public class BufferPublisher implements IBufferPublisher {
     private final String hostName;
     private final String[] tags;
 
-    private List<IPublishHelper<T>> helpers =
+    private List<IPublishHelper> helpers =
         new LinkedList<>();
 
     public BufferPublisher(String hostName, String[] tags) {
@@ -49,8 +49,8 @@ public class BufferPublisher<T> implements IBufferPublisher<T> {
             hostName, rawCacheName);
     }
 
-    public void publish(PublishContext context, int sequence, T event) {
-        for (IPublishHelper<T> helper: helpers) {
+    public void publish(PublishContext context, int sequence, Event event) {
+        for (IPublishHelper helper: helpers) {
             try {
                 helper.publish(context, sequence, event);
             } catch (Throwable t) {
@@ -82,7 +82,7 @@ public class BufferPublisher<T> implements IBufferPublisher<T> {
      *
      * @param helper helper to add to the list
      */
-    public void addHelper(IPublishHelper<T> helper) {
+    public void addHelper(IPublishHelper helper) {
         helpers.add(helper);
     }
 }

--- a/appender-core/src/main/java/com/van/logging/BufferPublisher.java
+++ b/appender-core/src/main/java/com/van/logging/BufferPublisher.java
@@ -26,16 +26,18 @@ public class BufferPublisher<T> implements IBufferPublisher<T> {
 
     public PublishContext startPublish(String cacheName) {
         String namespacedCacheName = composeNamespacedCacheName(cacheName);
-		/* System.out.println(String.format("BEGIN publishing %s...",
-			namespacedCacheName)); */
+		if (VansLogger.logger.isDebugEnabled()) {
+            VansLogger.logger.debug(String.format("BEGIN publishing %s...", namespacedCacheName));
+        }
         PublishContext context = new PublishContext(namespacedCacheName,
             hostName, tags);
         for (IPublishHelper helper: helpers) {
             try {
                 helper.start(context);
             } catch (Throwable t) {
-                System.err.println(String.format("Cannot start publish with %s due to error: %s",
-                    helper, t.getMessage()));
+                VansLogger.logger.error(
+                    String.format("Cannot start publish with %s due to error", helper), t
+                );
             }
         }
         return context;
@@ -52,12 +54,11 @@ public class BufferPublisher<T> implements IBufferPublisher<T> {
             try {
                 helper.publish(context, sequence, event);
             } catch (Throwable t) {
-                System.err.println(String.format("Cannot publish with %s due to error: %s",
-                    helper, t.getMessage()));
+                VansLogger.logger.error(
+                    String.format("Cannot publish with %s due to error", helper), t
+                );
             }
         }
-        /* System.out.println(String.format("%d:%s", sequence,
-			layout.format(event))); */
     }
 
     public void endPublish(PublishContext context) {
@@ -65,12 +66,14 @@ public class BufferPublisher<T> implements IBufferPublisher<T> {
             try {
                 helper.end(context);
             } catch (Throwable t) {
-                System.err.println(String.format("Cannot end publish with %s due to error: %s",
-                    helper, t.getMessage()));
+                VansLogger.logger.error(
+                    String.format("Cannot end publish with %s due to error", helper), t
+                );
             }
         }
-		/* System.out.println(String.format("END publishing %s",
-			context.getCacheName())); */
+        if (VansLogger.logger.isDebugEnabled()) {
+            VansLogger.logger.debug(String.format("END publishing %s", context.getCacheName()));
+        }
     }
 
     /**

--- a/appender-core/src/main/java/com/van/logging/CapacityBasedBufferMonitor.java
+++ b/appender-core/src/main/java/com/van/logging/CapacityBasedBufferMonitor.java
@@ -42,7 +42,7 @@ public class CapacityBasedBufferMonitor<T> implements IBufferMonitor<T> {
             try {
                 cache.flushAndPublish();
             } catch (Exception ex) {
-                ex.printStackTrace();
+                VansLogger.logger.error("Cannot flush and publish", ex);
             }
         }
     }
@@ -50,7 +50,7 @@ public class CapacityBasedBufferMonitor<T> implements IBufferMonitor<T> {
     @Override
     public void shutDown() {
         if (this.verbose) {
-            System.out.println("CapacityBasedBufferMonitor: shutting down.");
+            VansLogger.logger.info("CapacityBasedBufferMonitor: shutting down.");
         }
     }
 

--- a/appender-core/src/main/java/com/van/logging/CapacityBasedBufferMonitor.java
+++ b/appender-core/src/main/java/com/van/logging/CapacityBasedBufferMonitor.java
@@ -4,7 +4,7 @@ package com.van.logging;
  * Implementation of {@link IBufferMonitor} that flushes the cache when its capacity
  * reaches a limit.
  */
-public class CapacityBasedBufferMonitor<T> implements IBufferMonitor<T> {
+public class CapacityBasedBufferMonitor implements IBufferMonitor {
 
     private final int cacheLimit;
     private final Object countGuard = new Object();
@@ -30,7 +30,7 @@ public class CapacityBasedBufferMonitor<T> implements IBufferMonitor<T> {
     }
 
     @Override
-    public void eventAdded(final T event, final IFlushAndPublish cache) {
+    public void eventAdded(final Event event, final IFlushAndPublish cache) {
         boolean flush = false;
         synchronized (countGuard) {
             if (++count >= cacheLimit) {

--- a/appender-core/src/main/java/com/van/logging/IBufferMonitor.java
+++ b/appender-core/src/main/java/com/van/logging/IBufferMonitor.java
@@ -5,7 +5,7 @@ package com.van.logging;
  * the implemented policy. The {@link IFlushAndPublish#flushAndPublish()}
  * can be used by implementations to flush the queue.
  */
-public interface IBufferMonitor<T> {
+public interface IBufferMonitor {
     /**
      * A log event has just been added to the event buffer. Handlers
      * can decide to flush the buffer if the conditions are right.
@@ -13,7 +13,7 @@ public interface IBufferMonitor<T> {
      * @param event the event just added to the buffer.
      * @param flushAndPublisher the {@link IFlushAndPublish} to use to publish.
      */
-    void eventAdded(final T event, final IFlushAndPublish flushAndPublisher);
+    void eventAdded(final Event event, final IFlushAndPublish flushAndPublisher);
 
     /**
      * Shut down the monitor and clean up

--- a/appender-core/src/main/java/com/van/logging/IBufferPublisher.java
+++ b/appender-core/src/main/java/com/van/logging/IBufferPublisher.java
@@ -6,7 +6,7 @@ package com.van.logging;
  * @author vly
  *
  */
-public interface IBufferPublisher<T> {
+public interface IBufferPublisher {
 
     /**
      * Start a batch of events with the given name.  Implementations should
@@ -27,7 +27,7 @@ public interface IBufferPublisher<T> {
      * @param event the logging event
      */
     void publish(final PublishContext context, final int sequence,
-                 final T event);
+                 final Event event);
 
     /**
      * Concludes a publish batch.  Implementations should submit/commit

--- a/appender-core/src/main/java/com/van/logging/IPublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/IPublishHelper.java
@@ -7,7 +7,7 @@ package com.van.logging;
  * @author vly
  *
  */
-public interface IPublishHelper<T> {
+public interface IPublishHelper {
     /**
      * A publish batch is starting.  This is a good place to (re)initialize
      * a buffer.
@@ -26,7 +26,7 @@ public interface IPublishHelper<T> {
      * @param sequence counter of the sequence of this event in the batch
      * @param event the log event
      */
-    void publish(PublishContext context, int sequence, T event);
+    void publish(PublishContext context, int sequence, Event event);
 
     /**
      * A publish batch has ended.  Implementations should conclude a batch

--- a/appender-core/src/main/java/com/van/logging/TimePeriodBasedBufferMonitor.java
+++ b/appender-core/src/main/java/com/van/logging/TimePeriodBasedBufferMonitor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * This means that, if there were ever a relatively "quiet" period when there isn't at least
  * one event added to the cache, then nothing will be flushed and published.
  */
-public class TimePeriodBasedBufferMonitor<T> implements IBufferMonitor<T> {
+public class TimePeriodBasedBufferMonitor<T> implements IBufferMonitor {
 
     private final ScheduledExecutorService scheduledExecutorService =
         Executors.newScheduledThreadPool(1);
@@ -50,7 +50,7 @@ public class TimePeriodBasedBufferMonitor<T> implements IBufferMonitor<T> {
     }
 
     @Override
-    public void eventAdded(final T event, final IFlushAndPublish publisher) {
+    public void eventAdded(final Event event, final IFlushAndPublish publisher) {
         if (!monitorStarted.getAndSet(true)) {
             TimeDurationTuple tuple = getSchedulingTimeDuration();
             scheduledExecutorService.scheduleAtFixedRate(

--- a/appender-core/src/main/java/com/van/logging/TimePeriodBasedBufferMonitor.java
+++ b/appender-core/src/main/java/com/van/logging/TimePeriodBasedBufferMonitor.java
@@ -62,11 +62,11 @@ public class TimePeriodBasedBufferMonitor<T> implements IBufferMonitor<T> {
                         try {
                             publisher.flushAndPublish();
                         } catch (Exception ex) {
-                            ex.printStackTrace();
+                            VansLogger.logger.error("Cannot flush and publish", ex);
                         } finally {
                             long now = System.currentTimeMillis();
                             if (now - started > (periodInSeconds * 9 / 10)) {
-                                System.err.println(
+                                VansLogger.logger.warn(
                                     "Publish operation is approaching monitor period. Increase " +
                                     "period or risk compromising fixed rate.");
                             }
@@ -81,7 +81,7 @@ public class TimePeriodBasedBufferMonitor<T> implements IBufferMonitor<T> {
     @Override
     public void shutDown() {
         if (this.verbose) {
-            System.out.println("TimePeriodBasedBufferMonitor: shutting down.");
+            VansLogger.logger.info("TimePeriodBasedBufferMonitor: shutting down.");
         }
         this.scheduledExecutorService.shutdownNow();
     }

--- a/appender-core/src/main/java/com/van/logging/VansLogger.java
+++ b/appender-core/src/main/java/com/van/logging/VansLogger.java
@@ -1,0 +1,13 @@
+package com.van.logging;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Logger used by the log4j-s3-search classes for internal status and errors.
+ */
+public class VansLogger {
+    public static final Logger logger = LogManager.getLogger(VansLogger.class);
+}

--- a/appender-core/src/main/java/com/van/logging/aws/S3PublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/aws/S3PublishHelper.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.*;
 import com.van.logging.AbstractFilePublishHelper;
 import com.van.logging.IStorageDestinationAdjuster;
 import com.van.logging.PublishContext;
+import com.van.logging.VansLogger;
 import com.van.logging.utils.PublishHelperUtils;
 import com.van.logging.utils.StringUtils;
 import org.apache.http.entity.ContentType;
@@ -99,11 +100,13 @@ public class S3PublishHelper extends AbstractFilePublishHelper {
         );
         String key = getKey(context, path, isCompressionEnabled, keyGzSuffix);
         if (this.verbose) {
-            System.out.println(String.format("Publishing to S3 (bucket=%s; key=%s):", bucket, key));
+            VansLogger.logger.debug(String.format("Publishing to S3 (bucket=%s; key=%s):", bucket, key));
         }
 
         try {
-            // System.out.println(String.format("Publishing content of %s to S3.", tempFile));
+            if (VansLogger.logger.isDebugEnabled()) {
+                VansLogger.logger.debug(String.format("Publishing content of %s to S3.", file));
+            }
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(file.length());
             metadata.setContentType(ContentType.DEFAULT_BINARY.getMimeType());
@@ -121,7 +124,9 @@ public class S3PublishHelper extends AbstractFilePublishHelper {
             por.setMetadata(metadata);
 
             PutObjectResult result = client.putObject(por);
-            // System.out.println(String.format("Content MD5: %s", result.getContentMd5()));
+            if (VansLogger.logger.isDebugEnabled()) {
+                VansLogger.logger.debug(String.format("Content MD5: %s", result.getContentMd5()));
+            }
         } catch (Exception ex) {
             throw new RuntimeException(String.format("Cannot publish to S3: %s", ex.getMessage()), ex);
         }

--- a/appender-core/src/main/java/com/van/logging/azure/BlobPublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/azure/BlobPublishHelper.java
@@ -6,6 +6,7 @@ import com.microsoft.azure.storage.blob.*;
 import com.van.logging.AbstractFilePublishHelper;
 import com.van.logging.IStorageDestinationAdjuster;
 import com.van.logging.PublishContext;
+import com.van.logging.VansLogger;
 import com.van.logging.utils.PublishHelperUtils;
 import com.van.logging.utils.StringUtils;
 
@@ -62,7 +63,7 @@ public class BlobPublishHelper extends AbstractFilePublishHelper {
         );
         String blobName = getBlobName(context, path, blobConfiguration);
         if (this.verbose) {
-            System.out.println(String.format("Publishing %s to Azure blob (container=%s; blob=%s):",
+            VansLogger.logger.debug(String.format("Publishing %s to Azure blob (container=%s; blob=%s):",
                 file.getAbsolutePath(), blobConfiguration.getContainerName(), blobName));
         }
 
@@ -74,7 +75,7 @@ public class BlobPublishHelper extends AbstractFilePublishHelper {
         }
         blob.uploadFromFile(file.getAbsolutePath());
         if (this.verbose) {
-            System.out.println(String.format("Publishing to Azure blob %s done.", blobName));
+            VansLogger.logger.debug(String.format("Publishing to Azure blob %s done.", blobName));
         }
     }
 }

--- a/appender-core/src/main/java/com/van/logging/elasticsearch/IElasticsearchPublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/elasticsearch/IElasticsearchPublishHelper.java
@@ -8,7 +8,7 @@ import com.van.logging.IPublishHelper;
 /**
  * Interface for implementations of an IPublishHelper to publish events to Elasticsearch.
  */
-public interface IElasticsearchPublishHelper extends IPublishHelper<Event> {
+public interface IElasticsearchPublishHelper extends IPublishHelper {
 
     /**
      * Initialize the publish helper immediately after construction

--- a/appender-core/src/main/java/com/van/logging/gcp/CloudStoragePublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/gcp/CloudStoragePublishHelper.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.*;
 import com.van.logging.AbstractFilePublishHelper;
 import com.van.logging.IStorageDestinationAdjuster;
 import com.van.logging.PublishContext;
+import com.van.logging.VansLogger;
 import com.van.logging.utils.PublishHelperUtils;
 import com.van.logging.utils.StringUtils;
 
@@ -56,7 +57,7 @@ public class CloudStoragePublishHelper extends AbstractFilePublishHelper {
         );
         String blobName = getBlobName(context, path, configuration);
         if (this.verbose) {
-            System.out.println(String.format("Publishing %s to GCS blob (bucket=%s; blob=%s):",
+            VansLogger.logger.debug(String.format("Publishing %s to GCS blob (bucket=%s; blob=%s):",
                 file.getAbsolutePath(), bucketName, blobName));
         }
         BlobId blobId = BlobId.of(bucketName, blobName);

--- a/appender-core/src/main/java/com/van/logging/solr/SolrConfiguration.java
+++ b/appender-core/src/main/java/com/van/logging/solr/SolrConfiguration.java
@@ -1,5 +1,6 @@
 package com.van.logging.solr;
 
+import com.van.logging.VansLogger;
 import com.van.logging.utils.StringUtils;
 
 import java.net.MalformedURLException;
@@ -23,7 +24,7 @@ public class SolrConfiguration {
             try {
                 this.url = new URL(solrUrl);
             } catch (MalformedURLException e) {
-                e.printStackTrace();
+                VansLogger.logger.error(String.format("Cannot set Solr URL to %s", solrUrl), e);
             }
         }
     }

--- a/appender-core/src/main/java/com/van/logging/solr/SolrPublishHelper.java
+++ b/appender-core/src/main/java/com/van/logging/solr/SolrPublishHelper.java
@@ -19,7 +19,7 @@ import java.util.List;
  * @author vly
  *
  */
-public class SolrPublishHelper implements IPublishHelper<Event> {
+public class SolrPublishHelper implements IPublishHelper {
     private final SolrClient client;
 
     private int offset;

--- a/appender-core/src/test/java/com/van/logging/LoggingEventCacheTest.java
+++ b/appender-core/src/test/java/com/van/logging/LoggingEventCacheTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 public class LoggingEventCacheTest {
     private static final String CACHE_NAME = "test-cache";
 
-    private static class PublisherStub implements IBufferPublisher<String> {
+    private static class PublisherStub implements IBufferPublisher {
 
         @Override
         public PublishContext startPublish(String cacheName) {
@@ -14,7 +14,7 @@ public class LoggingEventCacheTest {
         }
 
         @Override
-        public void publish(PublishContext context, int sequence, String event) {
+        public void publish(PublishContext context, int sequence, Event event) {
 
         }
 
@@ -24,11 +24,11 @@ public class LoggingEventCacheTest {
         }
     };
 
-    public static final class TestMonitor implements IBufferMonitor<String> {
+    public static final class TestMonitor implements IBufferMonitor {
         private boolean isShutdown = false;
 
         @Override
-        public void eventAdded(String event, IFlushAndPublish flushAndPublisher) {
+        public void eventAdded(Event event, IFlushAndPublish flushAndPublisher) {
 
         }
 
@@ -43,7 +43,7 @@ public class LoggingEventCacheTest {
     public void testShutdown() {
         final TestMonitor monitor = new TestMonitor();
         try {
-            LoggingEventCache<String> inst = new LoggingEventCache<>(CACHE_NAME, monitor, new PublisherStub(), true);
+            LoggingEventCache inst = new LoggingEventCache(CACHE_NAME, monitor, new PublisherStub(), true);
             LoggingEventCache.shutDown();
 
             Assert.assertTrue("Monitor is shut down when LoggingEventCache is shut down", monitor.isShutdown);
@@ -58,8 +58,8 @@ public class LoggingEventCacheTest {
         final TestMonitor monitor = new TestMonitor();
         final TestMonitor monitor2 = new TestMonitor();
         try {
-            LoggingEventCache<String> inst = new LoggingEventCache<>(CACHE_NAME, monitor, new PublisherStub(), true);
-            LoggingEventCache<String> inst2 = new LoggingEventCache<>(CACHE_NAME, monitor2, new PublisherStub(), true);
+            LoggingEventCache inst = new LoggingEventCache(CACHE_NAME, monitor, new PublisherStub(), true);
+            LoggingEventCache inst2 = new LoggingEventCache(CACHE_NAME, monitor2, new PublisherStub(), true);
 
             LoggingEventCache.shutDown();
 

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Log4j 2.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>4.1.0</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>5.0.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -2,6 +2,7 @@ package com.van.logging.log4j2;
 
 import com.van.logging.Event;
 import com.van.logging.LoggingEventCache;
+import com.van.logging.VansLogger;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
@@ -39,18 +40,17 @@ public class Log4j2Appender extends AbstractAppender {
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             if (this.verbose) {
-                System.out.println("Publishing staging log on shutdown...");
+                VansLogger.logger.info("Publishing staging log on shutdown...");
             }
             eventCache.flushAndPublish(true);
             try {
                 if (this.verbose) {
-                    System.out.println("Shutting down LoggingEventCache...");
+                    VansLogger.logger.info("Shutting down LoggingEventCache...");
                 }
                 LoggingEventCache.shutDown();
             } catch (InterruptedException e) {
                 if (this.verbose) {
-                    System.out.println("InterruptedException during LoggingEventCache.shutDown");
-                    e.printStackTrace(System.out);
+                    VansLogger.logger.error("InterruptedException during LoggingEventCache.shutDown", e);
                 }
             }
         }));
@@ -65,10 +65,12 @@ public class Log4j2Appender extends AbstractAppender {
         try {
             eventCache.add(mapToEvent(logEvent));
         } catch (Exception ex) {
-            ex.printStackTrace();
+            VansLogger.logger.error("Cannot append to event cache", ex);
         }
         if (this.verbose) {
-            System.out.println(String.format("Log4j2Appender says: %s", logEvent.getMessage().getFormattedMessage()));
+            VansLogger.logger.info(
+                String.format("Log4j2Appender says: %s", logEvent.getMessage().getFormattedMessage())
+            );
         }
     }
 

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 @Plugin(name = "Log4j2Appender", category = "Core", elementType = "appender")
 public class Log4j2Appender extends AbstractAppender {
 
-    private final LoggingEventCache<Event> eventCache;
+    private final LoggingEventCache eventCache;
     private boolean verbose = false;
 
     @PluginBuilderFactory
@@ -32,7 +32,7 @@ public class Log4j2Appender extends AbstractAppender {
         Filter filter,
         Layout<? extends Serializable> layout,
         boolean ignoreExceptions,
-        LoggingEventCache<Event> eventCache
+        LoggingEventCache eventCache
     ) {
         super(name, filter, layout, ignoreExceptions);
         Objects.requireNonNull(eventCache);

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -136,7 +136,7 @@ public class Log4j2AppenderBuilder
     public Log4j2Appender build() {
         try {
             String cacheName = UUID.randomUUID().toString().replaceAll("-","");
-            LoggingEventCache<Event> cache = new LoggingEventCache<>(
+            LoggingEventCache cache = new LoggingEventCache(
                 cacheName, createCacheMonitor(), createCachePublisher(), verbose);
             Log4j2Appender appender = new Log4j2Appender(
                 getName(), getFilter(), getLayout(),
@@ -261,11 +261,11 @@ public class Log4j2AppenderBuilder
         return Optional.ofNullable(config);
     }
 
-    IBufferPublisher<Event> createCachePublisher() throws UnknownHostException {
+    IBufferPublisher createCachePublisher() throws UnknownHostException {
 
         java.net.InetAddress addr = java.net.InetAddress.getLocalHost();
         String hostName = addr.getHostName();
-        BufferPublisher<Event> publisher = new BufferPublisher<Event>(hostName, parseTags(tags));
+        BufferPublisher publisher = new BufferPublisher(hostName, parseTags(tags));
         PatternedPathAdjuster pathAdjuster = new PatternedPathAdjuster();
 
         getS3ConfigIfEnabled().ifPresent(config -> {
@@ -325,10 +325,10 @@ public class Log4j2AppenderBuilder
         return parsedTags.toArray(new String[] {});
     }
 
-    IBufferMonitor<Event> createCacheMonitor() {
-        IBufferMonitor<Event> monitor = new CapacityBasedBufferMonitor<Event>(stagingBufferSize, verbose);
+    IBufferMonitor createCacheMonitor() {
+        IBufferMonitor monitor = new CapacityBasedBufferMonitor(stagingBufferSize, verbose);
         if (0 < stagingBufferAge) {
-            monitor = new TimePeriodBasedBufferMonitor<Event>(stagingBufferAge);
+            monitor = new TimePeriodBasedBufferMonitor(stagingBufferAge);
         }
         if (verbose) {
             VansLogger.logger.info(String.format("Using cache monitor: %s", monitor));

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -270,7 +270,7 @@ public class Log4j2AppenderBuilder
 
         getS3ConfigIfEnabled().ifPresent(config -> {
             if (verbose) {
-                System.out.println(String.format(
+                VansLogger.logger.info(String.format(
                     "Registering AWS S3 publish helper -> %s", config));
             }
             publisher.addHelper(new S3PublishHelper(config, pathAdjuster, verbose));
@@ -278,21 +278,21 @@ public class Log4j2AppenderBuilder
 
         getBlobConfigurationIfEnabled().ifPresent(config -> {
             if (verbose) {
-                System.out.println(String.format("Registering Azure Blob Storage publish helper -> %s", config));
+                VansLogger.logger.info(String.format("Registering Azure Blob Storage publish helper -> %s", config));
             }
             publisher.addHelper(new BlobPublishHelper(config, pathAdjuster, verbose));
         });
 
         getCloudStorageConfigurationIfEnabled().ifPresent(config -> {
             if (verbose) {
-                System.out.println(String.format("Registering Google Cloud Storage publish helper -> %s", config));
+                VansLogger.logger.info(String.format("Registering Google Cloud Storage publish helper -> %s", config));
             }
             publisher.addHelper(new CloudStoragePublishHelper(config, pathAdjuster, verbose));
         });
 
         getSolrConfigurationIfEnabled(solrUrl).ifPresent(config -> {
             if (verbose) {
-                System.out.println(String.format(
+                VansLogger.logger.info(String.format(
                     "Registering SOLR publish helper -> %s", config));
             }
             publisher.addHelper(new SolrPublishHelper(config.getUrl()));
@@ -300,7 +300,7 @@ public class Log4j2AppenderBuilder
 
         getElasticsearchConfigIfEnabled().ifPresent(config -> {
             if (verbose) {
-                System.out.println(String.format(
+                VansLogger.logger.info(String.format(
                     "Registering Elasticsearch publish helper -> %s", config));
             }
             IElasticsearchPublishHelper helper = ElasticsearchPublishHelper.getPublishHelper(
@@ -331,7 +331,7 @@ public class Log4j2AppenderBuilder
             monitor = new TimePeriodBasedBufferMonitor<Event>(stagingBufferAge);
         }
         if (verbose) {
-            System.out.println(String.format("Using cache monitor: %s", monitor.toString()));
+            VansLogger.logger.info(String.format("Using cache monitor: %s", monitor));
         }
         return monitor;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
 version: '3'
+
+# This docker-compose.yml configures two services to run locally to support local instances of Solr and Elasticsearch
+# The instances can be used for development/testing.
+
+# To bring up the Solr server, for example, use `docker-compose up solr`. Similarly, to bring up the Elasticsearch
+# server, use `docker-compose up elasticsearch`. Or just `docker-compose up` to bring both up.
+
 services:
-  app:
-    build: .
-    volumes:
-      - ./:/code
-    networks:
-      - network
-    tty: true
-    stdin_open: true
   solr:
+    # To get the Solr container up, you need to set the environment variable SOLR_CORE_DIR to somewhere that has all the
+    # configuration files and folders set up. An example is misc/solr.
+    # See misc/solr/README.md for more information on how this is set up and how to use it.
     image: solr:8.11.2
     volumes:
       - ${SOLR_CORE_DIR}:/var/solr
@@ -22,6 +24,7 @@ services:
       - solr-precreate
       - log4js3
   elasticsearch:
+    # See misc/elasticsearch/README.md for more information on how this is set up and how to use it.
     image: elasticsearch:7.17.6
     environment:
       - discovery.type=single-node

--- a/misc/solr/README.md
+++ b/misc/solr/README.md
@@ -13,5 +13,7 @@ To use this:
   docker-compose up solr
   ```
 * The Solr server will be accessible at http://localhost:8983/solr/#/
+* The index `log4js3` is used. If you want to use a different index/core name, modify the `docker-compose.yml` file 
+  and also your log4j configuration file's `solrUrl`.
 * You can take a look at https://github.com/bluedenim/log4j-s3-search-samples/blob/master/appender-log4j2-sample/src/main/resources/log4j2.xml#L55-L56
   to see how to configure a program to send logs to it.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>log4j-s3-search</name>
     <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.apache.solr</groupId>
                 <artifactId>solr-solrj</artifactId>
-                <version>8.11.1</version>
+                <version>8.11.2</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>


### PR DESCRIPTION
Also: Now that support for Log4j1 is out, refactoring to remove unnecessary generics that just makes the code more complicated than it needs to be.