### PR TITLE
Avoid Thread Leak when used dynamically in a Route

### DIFF
--- a/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
+++ b/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
@@ -280,6 +280,7 @@ public class LoggingEventCache implements IFlushAndPublish {
                 success = success & terminated;
             } catch (Exception ex) {
                 VansLogger.logger.error(String.format("LoggingEventCache: error shutting down %s", executorService), ex);
+                success = false;
             }
         }
 

--- a/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
+++ b/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
@@ -1,10 +1,19 @@
 package com.van.logging;
 
-import org.apache.logging.log4j.core.LogEvent;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Queue;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -7,12 +7,11 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.plugins.*;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * The composite appender used to route log messages to various outlets. The name will have "CVL" prepended for
@@ -71,41 +70,9 @@ public class Log4j2Appender extends AbstractAppender {
     }
 
     @Override
-    protected boolean stop(long timeout, TimeUnit timeUnit, boolean changeLifeCycleState) {
-        VansLogger.logger.info("stop(timeout, timeunit, changeLifeCycleState)");
-        return super.stop(timeout, timeUnit, changeLifeCycleState);
-    }
-
-    @Override
-    protected void setStopped() {
-        VansLogger.logger.info("setStopped()");
-        super.setStopped();
-    }
-
-    @Override
-    protected void setStopping() {
-        VansLogger.logger.info("setStopping()");
-        super.setStopping();
-    }
-
-    @Override
-    protected boolean stop(Future<?> future) {
-        VansLogger.logger.info("stop(future)");
-        return super.stop(future);
-    }
-
-    @Override
     public void stop() {
-        VansLogger.logger.info("stop()");
         close();
         super.stop();
-    }
-
-    @Override
-    public boolean stop(long timeout, TimeUnit timeUnit) {
-        VansLogger.logger.info("stop(timeout, timeunit)");
-        close();
-        return super.stop(timeout, timeUnit);
     }
 
     Event mapToEvent(LogEvent event) {

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -1,6 +1,12 @@
 package com.van.logging.log4j2;
 
-import com.van.logging.*;
+import com.van.logging.BufferPublisher;
+import com.van.logging.CapacityBasedBufferMonitor;
+import com.van.logging.IBufferMonitor;
+import com.van.logging.IBufferPublisher;
+import com.van.logging.LoggingEventCache;
+import com.van.logging.TimePeriodBasedBufferMonitor;
+import com.van.logging.VansLogger;
 import com.van.logging.aws.S3Configuration;
 import com.van.logging.aws.S3PublishHelper;
 import com.van.logging.azure.BlobConfiguration;
@@ -18,7 +24,11 @@ import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
 
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -138,8 +148,6 @@ public class Log4j2AppenderBuilder
     @Override
     public Log4j2Appender build() {
         try {
-            VansLogger.logger.info("Building new Log4j2Appender...");
-            printStackTrace();
             String cacheName = UUID.randomUUID().toString().replaceAll("-","");
             LoggingEventCache cache = new LoggingEventCache(
                 cacheName, createCacheMonitor(), createCachePublisher(), verbose);
@@ -342,14 +350,5 @@ public class Log4j2AppenderBuilder
             VansLogger.logger.info(String.format("Using cache monitor: %s", monitor));
         }
         return monitor;
-    }
-
-    private void printStackTrace() {
-        System.out.println("Printing stack trace:");
-        StackTraceElement[] elements = Thread.currentThread().getStackTrace();
-        for (int i = 1; i < elements.length; i++) {
-            StackTraceElement s = elements[i];
-            System.out.println("\tat " + s.getClassName() + "." + s.getMethodName() + "(" + s.getFileName() + ":" + s.getLineNumber() + ")");
-        }
     }
 }

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2AppenderBuilder.java
@@ -138,6 +138,8 @@ public class Log4j2AppenderBuilder
     @Override
     public Log4j2Appender build() {
         try {
+            VansLogger.logger.info("Building new Log4j2Appender...");
+            printStackTrace();
             String cacheName = UUID.randomUUID().toString().replaceAll("-","");
             LoggingEventCache cache = new LoggingEventCache(
                 cacheName, createCacheMonitor(), createCachePublisher(), verbose);
@@ -340,5 +342,14 @@ public class Log4j2AppenderBuilder
             VansLogger.logger.info(String.format("Using cache monitor: %s", monitor));
         }
         return monitor;
+    }
+
+    private void printStackTrace() {
+        System.out.println("Printing stack trace:");
+        StackTraceElement[] elements = Thread.currentThread().getStackTrace();
+        for (int i = 1; i < elements.length; i++) {
+            StackTraceElement s = elements[i];
+            System.out.println("\tat " + s.getClassName() + "." + s.getMethodName() + "(" + s.getFileName() + ":" + s.getLineNumber() + ")");
+        }
     }
 }

--- a/appender-log4j2/src/test/java/com/van/logging/log4j2/Log4j2AppenderTest.java
+++ b/appender-log4j2/src/test/java/com/van/logging/log4j2/Log4j2AppenderTest.java
@@ -1,0 +1,29 @@
+package com.van.logging.log4j2;
+
+import com.van.logging.LoggingEventCache;
+import junit.framework.TestCase;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+
+import static org.apache.logging.log4j.core.AbstractLifeCycle.DEFAULT_STOP_TIMEUNIT;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+public class Log4j2AppenderTest extends TestCase {
+
+    public void testClose() {
+        final String name = "test";
+        final Filter filter = mock(Filter.class);
+        final Layout layout = mock(Layout.class);
+        final LoggingEventCache loggingEventCache = mock(LoggingEventCache.class);
+        final Log4j2Appender appender = new Log4j2Appender(name, filter, layout, false, loggingEventCache);
+
+        expect(loggingEventCache.flushAndPublish(true)).andReturn(null);
+        expect(loggingEventCache.stop()).andReturn(true);
+        replay(loggingEventCache);
+        appender.stop(0, DEFAULT_STOP_TIMEUNIT);
+        verify(loggingEventCache);
+    }
+}

--- a/appender-log4j2/src/test/java/com/van/logging/log4j2/Log4j2AppenderTest.java
+++ b/appender-log4j2/src/test/java/com/van/logging/log4j2/Log4j2AppenderTest.java
@@ -5,7 +5,6 @@ import junit.framework.TestCase;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 
-import static org.apache.logging.log4j.core.AbstractLifeCycle.DEFAULT_STOP_TIMEUNIT;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
@@ -23,7 +22,7 @@ public class Log4j2AppenderTest extends TestCase {
         expect(loggingEventCache.flushAndPublish(true)).andReturn(null);
         expect(loggingEventCache.stop()).andReturn(true);
         replay(loggingEventCache);
-        appender.stop(0, DEFAULT_STOP_TIMEUNIT);
+        appender.stop();
         verify(loggingEventCache);
     }
 }


### PR DESCRIPTION
When the appender is used in conjunction with a Log4j2 routing appender, a thread leak results due to the appender being dynamically created and stopped.  This PR implements the `stop()` method of the Log4j2 lifecycle to ensure that the underlying `ExecutorService` used by the `LoggingEventCache` and attached to each appender instance is stopped when the appender is stopped as part of the purge policy associated with the routing appender.  Without this fix, the appender creates and leaks threads, eventually hitting the underlying OS limit.