### PR TITLE
Change appender-log4j2 to depend on appender-core 5.1.1-SNAPSHOT to line up versions

### DIFF
--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>5.1.0</version>
+            <version>5.1.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
The tweak will avoid compilation errors when a change to appender-core is made locally that is then depended on by appender-log4j2.