### PR TITLE
Ensure that cache monitor is shut down when appender is stopped

### DIFF
--- a/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
+++ b/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
@@ -77,9 +77,6 @@ public class LoggingEventCache implements IFlushAndPublish {
         while (null != instance) {
             try {
                 instance.stop();
-                if (null != instance.cacheMonitor) {
-                    instance.cacheMonitor.shutDown();
-                }
             } catch (Exception ex) {
                 VansLogger.logger.error(String.format("LoggingEventCache: error shutting down %s", instance), ex);
             } finally {
@@ -282,6 +279,10 @@ public class LoggingEventCache implements IFlushAndPublish {
                 VansLogger.logger.error(String.format("LoggingEventCache: error shutting down %s", executorService), ex);
                 success = false;
             }
+        }
+
+        if (null != cacheMonitor) {
+            cacheMonitor.shutDown();
         }
 
         return success;

--- a/appender-core/src/main/java/com/van/logging/TimePeriodBasedBufferMonitor.java
+++ b/appender-core/src/main/java/com/van/logging/TimePeriodBasedBufferMonitor.java
@@ -83,7 +83,9 @@ public class TimePeriodBasedBufferMonitor<T> implements IBufferMonitor {
         if (this.verbose) {
             VansLogger.logger.info("TimePeriodBasedBufferMonitor: shutting down.");
         }
-        this.scheduledExecutorService.shutdownNow();
+        if (!this.scheduledExecutorService.isShutdown()) {
+            this.scheduledExecutorService.shutdownNow();
+        }
     }
 
     @Override


### PR DESCRIPTION
@bluedenim Found one more leak after integrating the previous fix.  The `TimePeriodBasedBufferMonitor` also creates an executor service that is not properly being shut down when the dynamically allocated appender is stopped.  Simple fix is to move the shutdown call to the cache monitor into the same extracted method in the previous PR.  The good news here is that the previous fix did address the leak of the `LoggingEventCache-publish-thread`.  Now, we see a leak of the `TimePeriodBasedBufferMonitor-publish-trigger`, which this fix should address.