### PR TITLE
Tweaks to support building with OpenJDK 21.0.2; no functional changes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11.0.10
+    - name: Set up JDK termurin:21
       uses: actions/setup-java@v1
       with:
-        java-version: '11.0.10'
+        distribution: 'temurin'
+        java-version: '21'
     - name: Build with Maven
       run: mvn -U -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -28,14 +28,12 @@ The [packages in MVN Repo](https://mvnrepository.com/search?q=therealvan) should
 correct Java version (see below).
 
 
-| Release / tag   | JSDK version                                                                                   |
-|-----------------|------------------------------------------------------------------------------------------------|
-| 2.x and earlier | [Java SDK (JDK) 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) |
-| 3.x             | [Java SDK (JDK) 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)      |
+| Release / tag     | JSDK version                                                                                   |
+|-------------------|------------------------------------------------------------------------------------------------|
+| 2.x and earlier   | [Java SDK (JDK) 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) |
+| 5.2.1 and earlier | [Java SDK (JDK) 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)      |
+| 5.2.2+            | [OpenJDK 21](https://openjdk.org/projects/jdk/21/)                                             |
 
-Note that using [Java SDK (JDK) 14](https://docs.oracle.com/en/java/javase/14/) to build the projects locally will
-have errors. You can try basing your work on [PR 59](https://github.com/bluedenim/log4j-s3-search/pull/59) if you
-really need to build with the newer JDKs.
 
 ## Packages
 The project is broken up into several packages:

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
     <name>appender-core</name>
     <description>Core functionality to send content to various channels, used by appender-log4j2</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>5.1.0</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -156,6 +156,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.time=ALL-UNNAMED
+                        --add-opens java.base/java.time.format=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Log4j 2.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>5.1.0</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>5.1.1-SNAPSHOT</version>
+            <version>5.2.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -168,6 +168,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.time=ALL-UNNAMED
+                        --add-opens java.base/java.time.format=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
     <name>log4j-s3-search</name>
     <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>


### PR DESCRIPTION
Some uses of Powermock in the unit tests are running into errors like:
```
java.lang.reflect.InaccessibleObjectException: Unable to make private final native void java.lang.Object.wait0(long) 
throws java.lang.InterruptedException accessible: module java.base does not "opens java.lang"
to unnamed module @6debcae2
```

Adding a plug-in entry for `maven-surefire-plugin` with `--add-opens java.base/java.lang=ALL-UNNAMED` (among others) seems to do the trick.
