### PR TITLE
Prevent thread and object leak

### DIFF
--- a/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
+++ b/appender-core/src/main/java/com/van/logging/LoggingEventCache.java
@@ -285,6 +285,11 @@ public class LoggingEventCache implements IFlushAndPublish {
             cacheMonitor.shutDown();
         }
 
+        if (null != instances) {
+            // Remove the stopped cache from the queue to avoid a leak
+            instances.remove(this);
+        }
+
         return success;
     }
 }

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -101,34 +101,18 @@ public class Log4j2Appender extends AbstractAppender {
         }
 
         // Deregister shutdown hook to avoid unbounded growth of registered hooks
-        if (!isShuttingDown()) {
-            try {
-                Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
-            } catch (final Exception e) {
-                // Swallow the exception cause
-                VansLogger.logger.error("Error while removing shutdown hook", e);
-            }
+        try {
+            Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+        } catch (IllegalStateException e) {
+            // Swallow the exception
+            VansLogger.logger.warn("Already shutting down. Cannot remove shutdown hook.")
+        } catch (final Exception e) {
+            // Swallow the exception cause
+            VansLogger.logger.error("Error while removing shutdown hook", e);
         }
 
         // Flush and stop the cache associated with this appender
         eventCache.flushAndPublish(true);
         eventCache.stop();
-    }
-
-    /**
-     * Tests if the application is currently in the process of shutting down to avoid an
-     * {@link IllegalStateException} when attempting to deregister the real shutdown hook(s).
-     * @return {@code true} if the JVM  is in the processing of stopping or {@code false} otherwise.
-     */
-    private boolean isShuttingDown() {
-        try {
-            final Thread dummyHook = new Thread();
-            Runtime.getRuntime().addShutdownHook(dummyHook);
-            Runtime.getRuntime().removeShutdownHook(dummyHook);
-        } catch (final Exception e) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -99,7 +99,7 @@ public class Log4j2Appender extends AbstractAppender {
         if (this.verbose) {
             VansLogger.logger.info("Publishing staging log on close...");
         }
-        
+
         // Deregister shutdown hook to avoid unbounded growth of registered hooks
         Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
 

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -105,7 +105,7 @@ public class Log4j2Appender extends AbstractAppender {
             Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
         } catch (IllegalStateException e) {
             // Swallow the exception
-            VansLogger.logger.warn("Already shutting down. Cannot remove shutdown hook.")
+            VansLogger.logger.warn("Already shutting down. Cannot remove shutdown hook.");
         } catch (final Exception e) {
             // Swallow the exception cause
             VansLogger.logger.error("Error while removing shutdown hook", e);

--- a/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
+++ b/appender-log4j2/src/main/java/com/van/logging/log4j2/Log4j2Appender.java
@@ -101,10 +101,34 @@ public class Log4j2Appender extends AbstractAppender {
         }
 
         // Deregister shutdown hook to avoid unbounded growth of registered hooks
-        Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+        if (!isShuttingDown()) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+            } catch (final Exception e) {
+                // Swallow the exception cause
+                VansLogger.logger.error("Error while removing shutdown hook", e);
+            }
+        }
 
         // Flush and stop the cache associated with this appender
         eventCache.flushAndPublish(true);
         eventCache.stop();
+    }
+
+    /**
+     * Tests if the application is currently in the process of shutting down to avoid an
+     * {@link IllegalStateException} when attempting to deregister the real shutdown hook(s).
+     * @return {@code true} if the JVM  is in the processing of stopping or {@code false} otherwise.
+     */
+    private boolean isShuttingDown() {
+        try {
+            final Thread dummyHook = new Thread();
+            Runtime.getRuntime().addShutdownHook(dummyHook);
+            Runtime.getRuntime().removeShutdownHook(dummyHook);
+        } catch (final Exception e) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
@bluedenim We discovered two more leaks when using the appender with a router:

1. The number of registered shutdown hooks grows unbounded as new appender instances are created
2. The queue of `LoggingEventCache` instances grows unbounded as new appender instances are created

This PR attempts to fix both by:

* De-registering the shutdown hook thread when the `stop()` method is called by Log4j
* Removing the cache from the queue when the `stop()` method on the `LoggingEventCache` is called as part of the appender stop flow implemented previously.

I do wonder if the shutdown hook is even necessary at this point, even in the standard single appender creation flow.  Might be worth doing some testing to see if the `stop()` implementation makes the shutdown hook unnecessary, though it may still be a good safety net when an application crashes and Log4j cannot complete its shutdown flow.