### PR TITLE
Update elasticsearch dep to avoid vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-high-level-client</artifactId>
-                <version>7.17.6</version>
+                <version>7.17.21</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
@bluedenim Update to latest 1.17.x version of the Elasticsearch dependency to address the following vulnerabilities:

* https://github.com/advisories/GHSA-w5gg-2q56-6h4f
* https://github.com/advisories/GHSA-qwrx-45xf-jjf7
* https://github.com/advisories/GHSA-285m-vhfq-xx4h
* https://github.com/advisories/GHSA-2cqf-6xv9-f22w