### PR TITLE
Add "excludeHostFromLogName" option to exclude host name/IP from the log name uploaded

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,6 @@ jobs:
     - name: Set up JDK termurin:21
       uses: actions/setup-java@v1
       with:
-        distribution: 'temurin'
         java-version: '21'
     - name: Build with Maven
       run: mvn -U -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ In addition to the typical appender configuration (such as layout, Threshold, et
 *  **hostName** -- (_optional_) a string to use to indicate where this log comes from. If this is not configured, by 
          default it uses the host name where the logger is run. When set, this cannot be a blank string, or it will be
          ignored.
+*  **excludeHostFromLogName** -- (_optional_) if True, then the log name as uploaded to storage will not contain the host name.
 *  **tags** -- (_optional_) comma-separated tokens to associate to the log entries (used mainly for search filtering). 
     Examples:
     *  `production,webserver`
@@ -183,6 +184,10 @@ e.g.
 logs/myApplication/20150327081000_localhost_6187f4043f2449ccb4cbd3a7930d1130
 ```
 
+However, if the `excludeHostInLogName` property is set to `true`, then the `{hostname}` will NOT be included in
+the key. For the example above, the key would be `{s3Path}/yyyyMMddHH24mmss_{UUID w/ "-" stripped}`.
+
+
 Content configurations
 * **s3Compression** -- if set to "true," then contents will be GZIP'ed before publishing into S3
 * **s3KeyGzSuffixEnabled** -- if set to "true," then the s3 key will have a `.gz` suffix when `s3Compression` is 
@@ -223,6 +228,10 @@ e.g.
 
 logs/myApplication/20150327081000_localhost_6187f4043f2449ccb4cbd3a7930d1130
 ```
+
+However, if the `excludeHostInLogName` property is set to `true`, then the `{hostname}` will NOT be included in
+the blob name. For the example above, the key would be `{azureBlobNamePrefix}/yyyyMMddHH24mmss_{UUID w/ "-" stripped}`.
+
 
 Notes:
 * See https://docs.microsoft.com/en-us/rest/api/storageservices/Naming-and-Referencing-Containers--Blobs--and-Metadata 
@@ -275,6 +284,10 @@ e.g.
 
 logs/myApplication/20150327081000_localhost_6187f4043f2449ccb4cbd3a7930d1130
 ```
+
+However, if the `excludeHostInLogName` property is set to `true`, then the `{hostname}` will NOT be included in
+the blob name. For the example above, the key would be `{gcpStorageBlobNamePrefix}/yyyyMMddHH24mmss_{UUID w/ "-" stripped}`.
+
 
 ## Advanced Cloud Storage Configuration
 ### Dynamic Path/Prefix Pattern

--- a/appender-core/pom.xml
+++ b/appender-core/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-core</artifactId>
-    <version>5.3.3-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
     <name>appender-core</name>
     <description>Core functionality to send content to various channels, used by appender-log4j2</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>5.3.3-SNAPSHOT</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/appender-log4j2/pom.xml
+++ b/appender-log4j2/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appender-log4j2</artifactId>
-    <version>5.3.3-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
     <name>appender-log4j2</name>
     <description>Log4j 2.x appender to capture and send log events to remote storage (AWS S3, Azure Blob Storage, Google Cloud Storage) and search (Solr, Elasticsearch)</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.therealvan</groupId>
         <artifactId>log4j-s3-search</artifactId>
-        <version>5.3.3-SNAPSHOT</version>
+        <version>5.5.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.therealvan</groupId>
             <artifactId>appender-core</artifactId>
-            <version>5.3.3-SNAPSHOT</version>
+            <version>5.5.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/appender-log4j2/src/test/java/com/van/logging/log4j2/Log4j2AppenderBuilderTest.java
+++ b/appender-log4j2/src/test/java/com/van/logging/log4j2/Log4j2AppenderBuilderTest.java
@@ -75,7 +75,7 @@ public class Log4j2AppenderBuilderTest extends TestCase {
         }
         PublishContext context = null;
         try {
-            IBufferPublisher publisher = builder.createCachePublisher();
+            IBufferPublisher publisher = builder.createCachePublisher(false);
             context = publisher.startPublish("CACHENAME");
         } catch (UnknownHostException e) {
             fail(e.getMessage());
@@ -96,11 +96,34 @@ public class Log4j2AppenderBuilderTest extends TestCase {
         String hostName = addr.getHostName();
 
         try {
-            IBufferPublisher publisher = builder.createCachePublisher();
+            IBufferPublisher publisher = builder.createCachePublisher(false);
             context = publisher.startPublish("CACHENAME");
         } catch (UnknownHostException e) {
             fail(e.getMessage());
         }
         assertEquals(hostName, context.getHostName());
+        assertTrue(context.getCacheName().contains(hostName));
+    }
+
+    public void testCreatePublisherWithSimpleCacheName() {
+        Log4j2AppenderBuilder builder = new Log4j2AppenderBuilder();
+        PublishContext context = null;
+        String cacheName = "CACHENAME";
+
+        java.net.InetAddress addr = null;
+        try {
+            addr = java.net.InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            fail(e.getMessage());
+        }
+        String hostName = addr.getHostName();
+
+        try {
+            IBufferPublisher publisher = builder.createCachePublisher(true);
+            context = publisher.startPublish(cacheName);
+        } catch (UnknownHostException e) {
+            fail(e.getMessage());
+        }
+        assertFalse(context.getCacheName().contains(hostName));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
     <groupId>com.therealvan</groupId>
     <artifactId>log4j-s3-search</artifactId>
     <packaging>pom</packaging>
-    <version>5.3.3-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
     <name>log4j-s3-search</name>
-    <description>Parent POM for the log4j-s3-search project and used by appender-core, appender-log4j, and appender-log4j2 projects.</description>
+    <description>Parent POM for the log4j-s3-search project and used by appender-core and appender-log4j2 projects.</description>
     <url>https://github.com/bluedenim/log4j-s3-search</url>
     <developers>
         <developer>


### PR DESCRIPTION
Normally, the log name uploaded uses the format:
`{date/time}_{host name}_{log ID}`

If the new option `excludeHostFromLogName` is set to true, then the log name will be:
`{date/time}_{log ID}`

